### PR TITLE
Dev -> Main

### DIFF
--- a/ethylene-core/build.gradle
+++ b/ethylene-core/build.gradle
@@ -3,4 +3,4 @@ plugins {
 }
 
 group 'com.github.steanky'
-version '0.4.2'
+version '0.5.0'

--- a/ethylene-core/src/main/java/com/github/steanky/ethylene/core/BasicConfigHandler.java
+++ b/ethylene-core/src/main/java/com/github/steanky/ethylene/core/BasicConfigHandler.java
@@ -47,6 +47,11 @@ public class BasicConfigHandler implements ConfigHandler {
     }
 
     @Override
+    public <TData> boolean removeLoader(@NotNull ConfigKey<TData> key) {
+        return loaderMap.remove(key) != null;
+    }
+
+    @Override
     public @NotNull <TData> ConfigLoader<TData> getLoader(@NotNull ConfigKey<TData> key) {
         validatePresentKey(key);
 

--- a/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigElement.java
+++ b/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigElement.java
@@ -3,10 +3,11 @@ package com.github.steanky.ethylene.core;
 import com.github.steanky.ethylene.core.collection.ConfigContainer;
 import com.github.steanky.ethylene.core.collection.ConfigList;
 import com.github.steanky.ethylene.core.collection.ConfigNode;
-import com.github.steanky.ethylene.core.util.ConfigElementUtils;
+import com.github.steanky.ethylene.core.processor.ConfigProcessException;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -208,6 +209,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default @NotNull ConfigElement getElementOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, element -> true, Function.identity(), path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param elementSupplier the supplier used to produce the default value
@@ -216,7 +228,8 @@ public interface ConfigElement {
      */
     default ConfigElement getElementOrDefault(@NotNull Supplier<ConfigElement> elementSupplier,
                                               @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, elementSupplier, element -> true, element -> element, path);
+        return ConfigElementHelper.getOrDefault(this, elementSupplier, element -> true, Function.identity(),
+                path);
     }
 
     /**
@@ -231,6 +244,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default boolean getBooleanOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isBoolean, ConfigElement::asBoolean, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param booleanSupplier the supplier used to produce the default value
@@ -238,7 +262,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default boolean getBooleanOrDefault(@NotNull Supplier<Boolean> booleanSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, booleanSupplier, ConfigElement::isBoolean,
+        return ConfigElementHelper.getOrDefault(this, booleanSupplier, ConfigElement::isBoolean,
                 ConfigElement::asBoolean, path);
     }
 
@@ -254,6 +278,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default @NotNull Number getNumberOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isNumber, ConfigElement::asNumber, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param numberSupplier the supplier used to produce the default value
@@ -261,7 +296,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default Number getNumberOrDefault(@NotNull Supplier<Number> numberSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, numberSupplier, ConfigElement::isNumber,
+        return ConfigElementHelper.getOrDefault(this, numberSupplier, ConfigElement::isNumber,
                 ConfigElement::asNumber, path);
     }
 
@@ -277,6 +312,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default @NotNull String getStringOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isString, ConfigElement::asString, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param stringSupplier the supplier used to produce the default value
@@ -284,7 +330,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default String getStringOrDefault(@NotNull Supplier<String> stringSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, stringSupplier, ConfigElement::isString,
+        return ConfigElementHelper.getOrDefault(this, stringSupplier, ConfigElement::isString,
                 ConfigElement::asString, path);
     }
 
@@ -300,6 +346,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default @NotNull ConfigList getListOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isList, ConfigElement::asList, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param listSupplier the supplier used to produce the default value
@@ -307,7 +364,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default ConfigList getListOrDefault(@NotNull Supplier<ConfigList> listSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, listSupplier, ConfigElement::isList, ConfigElement::asList,
+        return ConfigElementHelper.getOrDefault(this, listSupplier, ConfigElement::isList, ConfigElement::asList,
                 path);
     }
 
@@ -323,6 +380,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default @NotNull ConfigNode getNodeOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isNode, ConfigElement::asNode, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param nodeSupplier the supplier used to produce the default value
@@ -330,7 +398,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default ConfigNode getNodeOrDefault(@NotNull Supplier<ConfigNode> nodeSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, nodeSupplier, ConfigElement::isNode, ConfigElement::asNode,
+        return ConfigElementHelper.getOrDefault(this, nodeSupplier, ConfigElement::isNode, ConfigElement::asNode,
                 path);
     }
 
@@ -346,6 +414,17 @@ public interface ConfigElement {
     }
 
     /**
+     * Works like {@link ConfigElement#getElement(Object...)}, but throws an informative {@link ConfigProcessException}
+     * if the path is invalid, or the value pointed to by the path is not the right type.
+     * @param path the object path
+     * @return the value located at the path
+     * @throws ConfigProcessException if the path or element type is invalid
+     */
+    default Object getObjectOrThrow(@NotNull Object... path) throws ConfigProcessException {
+        return ConfigElementHelper.getOrThrow(this, ConfigElement::isObject, ConfigElement::asObject, path);
+    }
+
+    /**
      * Works like {@link ConfigElement#getElement(Object...)}, but returns a default value if the path is invalid, or
      * the value pointed to by the path is not the right type.
      * @param objectSupplier the supplier used to produce the default value
@@ -353,7 +432,7 @@ public interface ConfigElement {
      * @return the value located at the path, or the default value
      */
     default Object getObjectOrDefault(@NotNull Supplier<Object> objectSupplier, @NotNull Object ... path) {
-        return ConfigElementUtils.getOrDefault(this, objectSupplier, ConfigElement::isObject,
+        return ConfigElementHelper.getOrDefault(this, objectSupplier, ConfigElement::isObject,
                 ConfigElement::asObject, path);
     }
 
@@ -364,7 +443,7 @@ public interface ConfigElement {
      * @param path the object path
      * @return the value located at the path, or the default value
      */
-    default Object getObjectOrDefault(@NotNull Object defaultObject, @NotNull Object ... path) {
+    default Object getObjectOrDefault(Object defaultObject, @NotNull Object ... path) {
         return getObjectOrDefault(() -> defaultObject, path);
     }
 }

--- a/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigElementHelper.java
+++ b/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigElementHelper.java
@@ -1,0 +1,84 @@
+package com.github.steanky.ethylene.core;
+
+import com.github.steanky.ethylene.core.processor.ConfigProcessException;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Internal utility class used by {@link ConfigElement}.
+ */
+final class ConfigElementHelper {
+    private ConfigElementHelper() { throw new AssertionError("Don't do this."); }
+
+    private static String pathToString(@NotNull Object... pathString) {
+        StringBuilder builder = new StringBuilder();
+        for(int i = 0; i < pathString.length; i++) {
+            builder.append(pathString[i]);
+            if(i < pathString.length - 1) {
+                builder.append('/');
+            }
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Static utility method used by {@link ConfigElement}. Acts as a wrapper for
+     * {@link ConfigElement#getElement(Object...)}, and will use the value supplied by the {@link Supplier} if the path
+     * does not exist, or the {@link Function} used to evaluate whether the type conversion may safely occur returns
+     * false. Otherwise, the type conversion Function will be called and its result returned.
+     * @param element the element to perform the operation on
+     * @param returnSupplier the supplier used to supply return values if the path or type is invalid
+     * @param typeValidator the function used to determine if the element type is valid
+     * @param typeGetter the function used to actually convert the element
+     * @param path the path to resolve
+     * @param <TReturn> the generic return value type
+     * @return the value stored in element at path, or the default value produced by the supplier
+     * @throws NullPointerException if any of the arguments are null
+     * @throws IllegalArgumentException if path contains invalid types (any besides Integer or String)
+     */
+    static <TReturn> @NotNull TReturn getOrDefault(@NotNull ConfigElement element,
+                                                   @NotNull Supplier<TReturn> returnSupplier,
+                                                   @NotNull Function<ConfigElement, Boolean> typeValidator,
+                                                   @NotNull Function<ConfigElement, TReturn> typeGetter,
+                                                   @NotNull Object ... path) {
+        ConfigElement newElement = element.getElement(path);
+
+        if(newElement != null && typeValidator.apply(newElement)) {
+            return typeGetter.apply(newElement);
+        }
+        else {
+            return returnSupplier.get();
+        }
+    }
+
+    /**
+     * Works like {@link ConfigElementHelper#getOrDefault(ConfigElement, Supplier, Function, Function, Object...)}, but
+     * throws a {@link ConfigProcessException} if the path is invalid or if the object cannot be converted to the
+     * desired type.
+     * @param element the element to perform the operation on
+     * @param typeValidator the function used to determine if the element type is valid
+     * @param typeGetter the function used to actually convert the element
+     * @param path the path to resolve
+     * @return the value stored in element at path
+     * @throws ConfigProcessException if the path is invalid, or the path is valid but the type is not
+     */
+    static <TReturn> @NotNull TReturn getOrThrow(@NotNull ConfigElement element,
+                                                 @NotNull Function<ConfigElement, Boolean> typeValidator,
+                                                 @NotNull Function<ConfigElement, TReturn> typeGetter,
+                                                 @NotNull Object ... path) throws ConfigProcessException {
+        ConfigElement newElement = element.getElement(path);
+
+        if(newElement != null) {
+            if(typeValidator.apply(newElement)) {
+                return typeGetter.apply(newElement);
+            }
+
+            throw new ConfigProcessException("ConfigElement " + newElement + " is of an invalid type");
+        }
+
+        throw new ConfigProcessException("Path " + pathToString(path) + " is invalid for " + element);
+    }
+}

--- a/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigHandler.java
+++ b/ethylene-core/src/main/java/com/github/steanky/ethylene/core/ConfigHandler.java
@@ -80,6 +80,14 @@ public interface ConfigHandler {
     <TData> void registerLoader(@NotNull ConfigKey<TData> key, @NotNull ConfigLoader<TData> loader);
 
     /**
+     * Removes the loader associated with this key.
+     * @param key the key associated with the loader
+     * @param <TData> the type of data returned by the loader
+     * @return true if a loader was removed, false otherwise
+     */
+    <TData> boolean removeLoader(@NotNull ConfigKey<TData> key);
+
+    /**
      * Retrieves the {@link ConfigLoader} instances associated with the provided key.
      * @param key the ConfigKey object associated with a loader
      * @param <TData> the type of data returned by the loader

--- a/ethylene-core/src/main/java/com/github/steanky/ethylene/core/util/ConfigElementUtils.java
+++ b/ethylene-core/src/main/java/com/github/steanky/ethylene/core/util/ConfigElementUtils.java
@@ -8,15 +8,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
-/**
- * Utility class used by {@link ConfigElement}. These methods are public for convenience, but not intended for general
- * use.
- */
 public final class ConfigElementUtils {
-    private ConfigElementUtils() { throw new AssertionError("Don't do this."); }
+    private ConfigElementUtils() {
+        throw new AssertionError("Why?");
+    }
 
     private static String toStringInternal(ConfigElement input, IdentityHashMap<Object, Integer> identities) {
         if(input.isContainer()) {
@@ -56,40 +52,6 @@ public final class ConfigElementUtils {
         }
         else {
             return "[" + input + "]";
-        }
-    }
-
-    /**
-     * Static utility method used by {@link ConfigElement}. Acts as a wrapper for
-     * {@link ConfigElement#getElement(Object...)}, and will use the value supplied by the {@link Supplier} if the path
-     * does not exist, or the {@link Function} used to evaluate whether the type conversion may safely occur returns
-     * false. Otherwise, the type conversion Function will be called and its result returned.
-     * @param element the element to perform the operation on
-     * @param returnSupplier the supplier used to supply return values if the path or type is invalid
-     * @param typeValidator the function used to determine if the element type is valid
-     * @param typeGetter the function used to actually convert the element
-     * @param path the path to resolve
-     * @param <TReturn> the generic return value type
-     * @return the value stored in element at path, or the default value produced by the supplier
-     * @throws NullPointerException if any of the arguments are null
-     * @throws IllegalArgumentException if path contains invalid types (any besides Integer or String)
-     */
-    public static <TReturn> @NotNull TReturn getOrDefault(@NotNull ConfigElement element,
-                                                          @NotNull Supplier<TReturn> returnSupplier,
-                                                          @NotNull Function<ConfigElement, Boolean> typeValidator,
-                                                          @NotNull Function<ConfigElement, TReturn> typeGetter,
-                                                          @NotNull Object ... path) {
-        Objects.requireNonNull(returnSupplier);
-        Objects.requireNonNull(typeValidator);
-        Objects.requireNonNull(typeGetter);
-
-        ConfigElement newElement = element.getElement(path);
-
-        if(newElement != null && typeValidator.apply(newElement)) {
-            return typeGetter.apply(newElement);
-        }
-        else {
-            return returnSupplier.get();
         }
     }
 

--- a/ethylene-hjson/build.gradle
+++ b/ethylene-hjson/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.steanky'
-version '0.3.2'
+version '0.5.0'
 
 dependencies {
     api project(':ethylene-core')

--- a/ethylene-json/build.gradle
+++ b/ethylene-json/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.steanky'
-version '0.4.2'
+version '0.5.0'
 
 dependencies {
     api project(':ethylene-core')

--- a/ethylene-json/src/main/java/com/github/steanky/ethylene/codec/json/JsonCodec.java
+++ b/ethylene-json/src/main/java/com/github/steanky/ethylene/codec/json/JsonCodec.java
@@ -26,7 +26,7 @@ public class JsonCodec extends AbstractConfigCodec {
     private final Gson gson;
 
     /**
-     * Creates a new JsonCodec using the provided {@link Gson} to read and write data.
+     * Creates a new JsonCodec using the provided {@link Gson} instance to read and write data.
      * @param gson the Gson instance to use
      * @throws NullPointerException if gson is null
      */

--- a/ethylene-toml/build.gradle
+++ b/ethylene-toml/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.steanky'
-version '0.4.2'
+version '0.5.0'
 
 dependencies {
     api project(':ethylene-core')

--- a/ethylene-yaml/build.gradle
+++ b/ethylene-yaml/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.github.steanky'
-version '0.3.2'
+version '0.5.0'
 
 dependencies {
     api project(':ethylene-core')

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,4 @@ include 'ethylene-json'
 include 'example-project'
 include 'ethylene-yaml'
 include 'ethylene-hjson'
-include 'ethylene-hjson'
 


### PR DESCRIPTION
**Description**</br>
Added `get[x]OrThrow` methods to ConfigElement, ConfigElementUtils no longer provides getOrDefault methods (these are now internal and only used by ConfigElement). 

**Issue Reference**</br>
N/A
